### PR TITLE
start button; orientation + button functionality issues

### DIFF
--- a/mainmenugui.java
+++ b/mainmenugui.java
@@ -1,11 +1,10 @@
 package Mainmenu;
+
 import java.awt.*;
-import java.awt.Color;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
 import java.awt.event.ActionListener;
 import java.awt.event.ActionEvent;
 import javax.swing.BorderFactory;
+import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JMenu;
@@ -39,7 +38,7 @@ class rungui extends JFrame {
 
             //layout setup -- constraints allows the gridx and y refs
             GridBagLayout mm = new GridBagLayout();
-            GridBagConstraints gbcmain = new GridBagConstraints();
+            GridBagConstraints welcomepanelgbc = new GridBagConstraints();
             
             //Menu Label
             JLabel welcomemess = new JLabel("Welcome to Velocity");
@@ -49,9 +48,28 @@ class rungui extends JFrame {
             welcomemess.setBorder(BorderFactory.createLineBorder(Color.BLACK));
             
             //label placement
-            gbcmain.gridx = 21;
-            gbcmain.gridy = 37;
-            panel.add(welcomemess,gbcmain);
+            welcomepanelgbc.gridx = 0;
+            welcomepanelgbc.gridy = 0;
+            panel.add(welcomemess,welcomepanelgbc);
+
+            //Enter button to take you to the Velocity app
+            JButton enterv = new JButton("Enter Velocity", null);
+            welcomepanelgbc.gridx = 0;
+            welcomepanelgbc.gridy = 0;
+            // need to find a way to make the button be horizontal to the panel, maybe im not using GBC properly?
+            
+            
+            ActionListener appinit = new ActionListener() {
+                
+                public void actionPerformed(ActionEvent appinit) {
+                    Mainmenu.Velocity.Velocity();
+                
+                }
+            };
+            
+            enterv.addActionListener(appinit);
+            panel.add(enterv);
+
 
             //Taskbar
 
@@ -60,8 +78,8 @@ class rungui extends JFrame {
             //New JMenu
             JMenu fileMenu = new JMenu("File");
             
-            //new MenuItems
-            JMenuItem exititem = new JMenuItem("Exit");
+            //new MenuItems and action listener for exit functionalitu from File/Exit
+            JMenuItem exititem = new JMenuItem("Exit Velocity");
             exititem.addActionListener(new ActionListener() {
                 public void actionPerformed(ActionEvent closegui) {
                     //Close the JFrame when the exit on JMenu item is clicked


### PR DESCRIPTION
Hey @faris-hamdy!

Added this new branch which has a start button which should initialise Velocity.java (previously names VG.java), now packaged under main menu. So now the app package is Mainmenu/mainmenigui.java and Mainmenu/Velocity.java part of the Mainmenu package. 

Problem #1 - Central orientation of the Enter Velocity button -- currently it is just orientating itself at the top directly right of the central main menu label. I suspect therefore that I have not used GridBagConstraints properly as perhaps it is placing both the main menu JLabel and the JButton alongside each other. Not sure where I have gone wrong here...

Problem #2 - I have added an action listener to the Velocity button, when clicked it should initialise the constructor of the VG class in the other file Velocity.java. _Something_ is happening in my terminal, however I am not seeing a new GUI created or new panel appearing so again I am a little stumped! 

This may be my last commit and pull request on this repo for a day or two cause Grad stuff, but feel free to add some commits to this branch, or better still, make a new branch and add some fixes and additions on there so then I can review where I went wrong here!